### PR TITLE
remove unwanted Leaflet marker border via CSS override

### DIFF
--- a/Viewer/css/leaflet-marker-overrides.css
+++ b/Viewer/css/leaflet-marker-overrides.css
@@ -1,0 +1,3 @@
+.leaflet-pane.leaflet-shadow-pane {
+    display: none;
+}

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       crossorigin=""></script>
    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
    <link rel="stylesheet" href="./Viewer/lib/leaflet-slider/dist/leaflet-slider.css" />
+   <link rel="stylesheet" href="./Viewer/css/leaflet-marker-overrides.css" />
    <link rel="stylesheet" href="./Viewer/css/referenceStationContent.css" />
    <script src="./Viewer/lib/leaflet-slider/dist/leaflet-slider.js"></script>
    <script src="./Viewer/lib/leaflet.sprite/dist/leaflet.sprite.js"></script>


### PR DESCRIPTION
#8 の修正
https://stackoverflow.com/questions/62529753/css-leaflet-markers-borders-stay-displayed-as-undesirable-effect
にしたがって、cssを追加した。