### PR TITLE
fix: mapLoaderのNTRIPホストのハードコードを削除 (#10)

### DIFF
--- a/Viewer/js/mapLoader.js
+++ b/Viewer/js/mapLoader.js
@@ -173,7 +173,7 @@ function convertStationDataToPopupText(referenceStationData) {
     <font size="4">
       ${referenceStationData.city_name}<br>
       北緯: ${referenceStationData.latitude}, 東経: ${referenceStationData.longitude}, 楕円体高: ${referenceStationData.geoid_height}<br>
-      サーバアドレス: ntrip.phys.info.hiroshima-cu.ac.jp${referenceStationData.server_address}<br>
+      サーバアドレス: ${referenceStationData.server_address}<br>
       ポート番号: ${referenceStationData.port_number}, データ形式: ${referenceStationData.data_type}, 接続形式: ${referenceStationData.connection_type}<br>
       コメント<br>
       <div class="comment-box">${referenceStationData.comment}</div>


### PR DESCRIPTION
## 概要

`mapLoader.js` にハードコードされていた NTRIP ホスト名を削除した。

## 変更内容

* サーバアドレスの表示に `referenceStationData.server_address` の値をそのまま使用するよう修正
* `ntrip.phys.info.hiroshima-cu.ac.jp` のハードコードを削除

## 関連Issue

* #10
