### PR TITLE
fix: スクレイピング結果を検証し、異常時のJSON更新を防止する (#12)

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -1,35 +1,50 @@
 name: Scrape action
-on: 
+
+on:
   workflow_dispatch:
   schedule:
     - cron: '0 15 * * *' # 毎日日本時間の0時に更新
+
 jobs:
   scrape:
     name: ruby
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
+
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1' 
+          ruby-version: '3.1'
+
       - name: bundle install
         run: |
           gem install bundler:2.1.4
           bundle install
         working-directory: ${{ github.workspace }}/Scraper
-      - name: run ruby
-        run: ruby scrape.rb
+
+      - name: Run tests
+        run: |
+          bundle exec ruby -Itest -e 'Dir["test/**/*_test.rb"].sort.each { |file| require File.expand_path(file) }'
         working-directory: ${{ github.workspace }}/Scraper
+
+      - name: Run scraper
+        run: bundle exec ruby scrape.rb
+        working-directory: ${{ github.workspace }}/Scraper
+
       - name: copy file
         run: cp result.json ../Viewer/resource
         working-directory: ${{ github.workspace }}/Scraper
+
       - name: git setting
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+
       - name: Commit files
         run: |
           git add -A
           if ! git diff-index --quiet HEAD --; then git commit -a -m "Update json (By GitHub Actions)"; fi;
           git push
+
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."

--- a/.github/workflows/scraper-test.yaml
+++ b/.github/workflows/scraper-test.yaml
@@ -1,0 +1,42 @@
+name: Scraper tests
+
+on:
+  push:
+    paths:
+      - 'Scraper/**'
+      - '.github/workflows/scraper-test.yaml'
+  pull_request:
+    paths:
+      - 'Scraper/**'
+      - '.github/workflows/scraper-test.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Ruby tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: Scraper
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+          working-directory: Scraper
+
+      - name: Run tests
+        run: >
+          bundle exec ruby -Itest -e
+          'Dir["test/**/*_test.rb"].sort.each {
+            |file| require File.expand_path(file)
+          }'

--- a/Scraper/Gemfile
+++ b/Scraper/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem 'nokogiri'
+gem 'minitest', group: :test

--- a/Scraper/Gemfile.lock
+++ b/Scraper/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    minitest (5.26.1)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     racc (1.8.0)
@@ -9,6 +10,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  minitest
   nokogiri
 
 BUNDLED WITH

--- a/Scraper/reference_station_parser.rb
+++ b/Scraper/reference_station_parser.rb
@@ -1,0 +1,21 @@
+module ReferenceStationParser
+  # 基準局一覧テーブルの1行を、公開用JSONに使用するデータへ変換する。
+  def self.parse_row(table_row)
+    cells = table_row.css('td')
+
+    {
+      'city_name' => cells[0].text,
+      'station_name' => cells[1].text,
+      'latitude' => cells[2].text,
+      'longitude' => cells[3].text,
+      'geoid_height' => cells[4].text,
+      'server_address' => cells[5].text,
+      'port_number' => cells[6].text,
+      'data_type' => cells[7].text,
+      'connection_type' => cells[8].text,
+      'status' => cells[9].text,
+      'mail' => cells[10].text,
+      'comment' => cells[11].inner_html
+    }
+  end
+end

--- a/Scraper/reference_station_parser.rb
+++ b/Scraper/reference_station_parser.rb
@@ -20,14 +20,24 @@ module ReferenceStationParser
   end
 
   # HTML文書から基準局一覧テーブルを特定し、
-  # 各データ行を基準局データへ変換する。
+  # 空行を除いた各データ行を基準局データへ変換する。
   def self.parse_document(document)
     table = find_reference_station_table(document)
-    rows = table.css('tr').drop(1)
 
-    rows.map do |row|
+    rows = table.css('tr').drop(1)
+    data_rows = rows.reject do |row|
+      empty_row?(row)
+    end
+
+    stations = data_rows.map do |row|
       parse_row(row)
     end
+
+    if stations.empty?
+      raise ParseError, '基準局データが0件です'
+    end
+
+    stations
   end
 
   # 基準局一覧テーブルの1行を、公開用JSONに使用するデータへ変換する。
@@ -86,6 +96,15 @@ module ReferenceStationParser
     table
   end
 
+  # td要素を持たない行、またはすべてのセルが空の行か判定する。
+  def self.empty_row?(row)
+    cells = row.css('td')
+
+    cells.empty? || cells.all? do |cell|
+      cell.text.strip.empty?
+    end
+  end
+
   def self.parse_coordinate(value, name:, range:)
     coordinate = Float(value)
 
@@ -101,5 +120,6 @@ module ReferenceStationParser
   end
 
   private_class_method :find_reference_station_table
+  private_class_method :empty_row?
   private_class_method :parse_coordinate
 end

--- a/Scraper/reference_station_parser.rb
+++ b/Scraper/reference_station_parser.rb
@@ -13,11 +13,23 @@ module ReferenceStationParser
             "基準局行の列数が不正です: expected=#{EXPECTED_COLUMN_COUNT}, actual=#{cells.length}"
     end
 
+    latitude = parse_coordinate(
+      cells[2].text,
+      name: '緯度',
+      range: -90.0..90.0
+    )
+
+    longitude = parse_coordinate(
+      cells[3].text,
+      name: '経度',
+      range: -180.0..180.0
+    )
+
     {
       'city_name' => cells[0].text,
       'station_name' => cells[1].text,
-      'latitude' => cells[2].text,
-      'longitude' => cells[3].text,
+      'latitude' => latitude,
+      'longitude' => longitude,
       'geoid_height' => cells[4].text,
       'server_address' => cells[5].text,
       'port_number' => cells[6].text,
@@ -28,4 +40,19 @@ module ReferenceStationParser
       'comment' => cells[11].inner_html
     }
   end
+
+  def self.parse_coordinate(value, name:, range:)
+    coordinate = Float(value)
+
+    unless range.cover?(coordinate)
+      raise ParseError,
+            "#{name}が範囲外です: value=#{coordinate}, range=#{range}"
+    end
+
+    coordinate
+  rescue ArgumentError, TypeError
+    raise ParseError, "#{name}を数値へ変換できません: value=#{value.inspect}"
+  end
+
+  private_class_method :parse_coordinate
 end

--- a/Scraper/reference_station_parser.rb
+++ b/Scraper/reference_station_parser.rb
@@ -1,7 +1,17 @@
 module ReferenceStationParser
+  EXPECTED_COLUMN_COUNT = 12
+
+  class ParseError < StandardError
+  end
+
   # 基準局一覧テーブルの1行を、公開用JSONに使用するデータへ変換する。
   def self.parse_row(table_row)
     cells = table_row.css('td')
+
+    if cells.length != EXPECTED_COLUMN_COUNT
+      raise ParseError,
+            "基準局行の列数が不正です: expected=#{EXPECTED_COLUMN_COUNT}, actual=#{cells.length}"
+    end
 
     {
       'city_name' => cells[0].text,

--- a/Scraper/reference_station_parser.rb
+++ b/Scraper/reference_station_parser.rb
@@ -1,7 +1,33 @@
 module ReferenceStationParser
   EXPECTED_COLUMN_COUNT = 12
 
+  EXPECTED_HEADERS = [
+    '都市名',
+    '局名',
+    '北緯',
+    '東経',
+    '楕円体高',
+    'サーバアドレス',
+    'ポート番号',
+    'データ形式',
+    '接続方法',
+    '状態',
+    'メール連絡',
+    'コメント'
+  ].freeze
+
   class ParseError < StandardError
+  end
+
+  # HTML文書から基準局一覧テーブルを特定し、
+  # 各データ行を基準局データへ変換する。
+  def self.parse_document(document)
+    table = find_reference_station_table(document)
+    rows = table.css('tr').drop(1)
+
+    rows.map do |row|
+      parse_row(row)
+    end
   end
 
   # 基準局一覧テーブルの1行を、公開用JSONに使用するデータへ変換する。
@@ -41,6 +67,25 @@ module ReferenceStationParser
     }
   end
 
+  def self.find_reference_station_table(document)
+    table = document.css('table').find do |candidate|
+      header_row = candidate.css('tr').first
+      next false if header_row.nil?
+
+      headers = header_row.css('th, td').map do |cell|
+        cell.text.strip
+      end
+
+      headers == EXPECTED_HEADERS
+    end
+
+    if table.nil?
+      raise ParseError, '基準局一覧テーブルが見つかりません'
+    end
+
+    table
+  end
+
   def self.parse_coordinate(value, name:, range:)
     coordinate = Float(value)
 
@@ -51,8 +96,10 @@ module ReferenceStationParser
 
     coordinate
   rescue ArgumentError, TypeError
-    raise ParseError, "#{name}を数値へ変換できません: value=#{value.inspect}"
+    raise ParseError,
+          "#{name}を数値へ変換できません: value=#{value.inspect}"
   end
 
+  private_class_method :find_reference_station_table
   private_class_method :parse_coordinate
 end

--- a/Scraper/reference_station_scraper.rb
+++ b/Scraper/reference_station_scraper.rb
@@ -1,0 +1,30 @@
+require_relative 'reference_station_parser'
+require_relative 'scraping_result_writer'
+
+module ReferenceStationScraper
+  # HTMLを解析して出力用データを生成し、
+  # すべての検証に成功した場合のみJSONファイルへ書き込む。
+  def self.run(document, output_path, updated_at: Time.now)
+    # HTMLから基準局一覧を解析し、検証済みの基準局データを取得
+    reference_stations =
+      ReferenceStationParser.parse_document(document)
+
+    # 各基準局に1から始まる連番IDを付与
+    station_data = reference_stations.map.with_index(1) do |station, id|
+      {
+        'id' => id
+      }.merge(station)
+    end
+
+    # 出力するJSONデータを作成
+    result = {
+      'UpdateTime(JST)' => updated_at.strftime('%Y-%m-%d %H:%M:%S'),
+      'ReferenceStationData' => station_data
+    }
+
+    # 検証済みのJSONデータを一時ファイル経由で安全に出力
+    ScrapingResultWriter.write(output_path, result)
+
+    result
+  end
+end

--- a/Scraper/scrape.rb
+++ b/Scraper/scrape.rb
@@ -1,23 +1,7 @@
 require 'open-uri'
 require 'nokogiri'
 require 'json'
-
-def read_kijunkyoku_table_row(table_row)
-  {
-    'city_name' => table_row.css('td')[0].text,
-    'station_name' => table_row.css('td')[1].text,
-    'latitude' => table_row.css('td')[2].text,
-    'longitude' => table_row.css('td')[3].text,
-    'geoid_height' => table_row.css('td')[4].text,
-    'server_address' => table_row.css('td')[5].text,
-    'port_number' => table_row.css('td')[6].text,
-    'data_type' => table_row.css('td')[7].text,
-    'connection_type' => table_row.css('td')[8].text,
-    'status' => table_row.css('td')[9].text,
-    'mail' => table_row.css('td')[10].text,
-    'comment' => table_row.css('td')[11].inner_html
-  }
-end
+require_relative 'reference_station_parser'
 
 if __FILE__ == $0
     # 善意の基準局のURL
@@ -43,7 +27,7 @@ if __FILE__ == $0
 
     # HTML内のtrタグからデータを取得してJSONに追加
     table_rows.drop(1).each.with_index(1) do |row, i|
-        json['ReferenceStationData'] << { 'id' => i }.merge(read_kijunkyoku_table_row(row))
+        json['ReferenceStationData'] << { 'id' => i }.merge(ReferenceStationParser.parse_row(row))
     end
 
     # JSONファイルを出力

--- a/Scraper/scrape.rb
+++ b/Scraper/scrape.rb
@@ -1,14 +1,14 @@
 require 'open-uri'
 require 'nokogiri'
-require 'json'
 require_relative 'reference_station_parser'
+require_relative 'scraping_result_writer'
 
 if __FILE__ == $0
     # 善意の基準局のURL
     URL = 'https://rtk.silentsystem.jp/'
 
     # 証明書ファイルの場所
-    CERT_DIRECTORY = './cert/rtk_cacert.pem';
+    CERT_DIRECTORY = './cert/rtk_cacert.pem'
 
     # URLからHTMLを取得
     doc = Nokogiri.HTML(URI.open(URL, ssl_ca_cert: CERT_DIRECTORY))
@@ -22,16 +22,16 @@ if __FILE__ == $0
         'ReferenceStationData' => []
     }
 
+    # 基準局データを取得
     reference_stations = ReferenceStationParser.parse_document(doc)
 
+    # 1から始まる連番IDを付与
     reference_stations.each.with_index(1) do |station, id|
-    json['ReferenceStationData'] << {
-        'id' => id
-    }.merge(station)
+        json['ReferenceStationData'] << {
+            'id' => id
+        }.merge(station)
     end
 
     # JSONファイルを出力
-    File.open(file_name, 'w') do |file|
-        file.puts(JSON.pretty_generate(json))
-    end
+    ScrapingResultWriter.write(file_name, json)
 end

--- a/Scraper/scrape.rb
+++ b/Scraper/scrape.rb
@@ -13,9 +13,6 @@ if __FILE__ == $0
     # URLからHTMLを取得
     doc = Nokogiri.HTML(URI.open(URL, ssl_ca_cert: CERT_DIRECTORY))
 
-    # HTML内のtrタグを全て取得
-    table_rows = doc.xpath('//tr')
-
     # 出力するJSONファイル名を指定
     file_name = 'result.json'
 
@@ -25,9 +22,12 @@ if __FILE__ == $0
         'ReferenceStationData' => []
     }
 
-    # HTML内のtrタグからデータを取得してJSONに追加
-    table_rows.drop(1).each.with_index(1) do |row, i|
-        json['ReferenceStationData'] << { 'id' => i }.merge(ReferenceStationParser.parse_row(row))
+    reference_stations = ReferenceStationParser.parse_document(doc)
+
+    reference_stations.each.with_index(1) do |station, id|
+    json['ReferenceStationData'] << {
+        'id' => id
+    }.merge(station)
     end
 
     # JSONファイルを出力

--- a/Scraper/scrape.rb
+++ b/Scraper/scrape.rb
@@ -1,37 +1,22 @@
 require 'open-uri'
 require 'nokogiri'
-require_relative 'reference_station_parser'
-require_relative 'scraping_result_writer'
+require_relative 'reference_station_scraper'
 
 if __FILE__ == $0
-    # 善意の基準局のURL
-    URL = 'https://rtk.silentsystem.jp/'
+  # 善意の基準局のURL
+  URL = 'https://rtk.silentsystem.jp/'
 
-    # 証明書ファイルの場所
-    CERT_DIRECTORY = './cert/rtk_cacert.pem'
+  # 証明書ファイルの場所
+  CERT_DIRECTORY = './cert/rtk_cacert.pem'
 
-    # URLからHTMLを取得
-    doc = Nokogiri.HTML(URI.open(URL, ssl_ca_cert: CERT_DIRECTORY))
+  # 出力するJSONファイル名
+  OUTPUT_FILE = 'result.json'
 
-    # 出力するJSONファイル名を指定
-    file_name = 'result.json'
+  # URLからHTMLを取得
+  document = Nokogiri.HTML(
+    URI.open(URL, ssl_ca_cert: CERT_DIRECTORY)
+  )
 
-    # 出力するJSONデータの雛形を作成
-    json = {
-        'UpdateTime(JST)' => Time.now.strftime('%Y-%m-%d %H:%M:%S'),
-        'ReferenceStationData' => []
-    }
-
-    # 基準局データを取得
-    reference_stations = ReferenceStationParser.parse_document(doc)
-
-    # 1から始まる連番IDを付与
-    reference_stations.each.with_index(1) do |station, id|
-        json['ReferenceStationData'] << {
-            'id' => id
-        }.merge(station)
-    end
-
-    # JSONファイルを出力
-    ScrapingResultWriter.write(file_name, json)
+  # HTMLを解析し、検証済みの基準局データをJSONへ出力
+  ReferenceStationScraper.run(document, OUTPUT_FILE)
 end

--- a/Scraper/scraping_result_writer.rb
+++ b/Scraper/scraping_result_writer.rb
@@ -1,0 +1,25 @@
+require 'fileutils'
+require 'json'
+require 'tempfile'
+
+module ScrapingResultWriter
+  # JSONを一時ファイルへ完全に書き込んだ後、
+  # 公開対象のファイルを置き換える。
+  def self.write(output_path, result)
+    output_path = File.expand_path(output_path)
+    output_directory = File.dirname(output_path)
+    json_text = JSON.pretty_generate(result)
+
+    Tempfile.create(
+      ['scraping-result', '.json.tmp'],
+      output_directory
+    ) do |temp_file|
+      temp_file.write(json_text)
+      temp_file.write("\n")
+      temp_file.flush
+      temp_file.close
+
+      FileUtils.mv(temp_file.path, output_path, force: true)
+    end
+  end
+end

--- a/Scraper/test/fixtures/reference_stations/empty.html
+++ b/Scraper/test/fixtures/reference_stations/empty.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>基準局データなしのテストデータ</title>
+</head>
+<body>
+  <h1>基準局一覧</h1>
+
+  <table>
+    <tr>
+      <th>都市名</th>
+      <th>局名</th>
+      <th>北緯</th>
+      <th>東経</th>
+      <th>楕円体高</th>
+      <th>サーバアドレス</th>
+      <th>ポート番号</th>
+      <th>データ形式</th>
+      <th>接続方法</th>
+      <th>状態</th>
+      <th>メール連絡</th>
+      <th>コメント</th>
+    </tr>
+  </table>
+</body>
+</html>

--- a/Scraper/test/fixtures/reference_stations/invalid_coordinates.html
+++ b/Scraper/test/fixtures/reference_stations/invalid_coordinates.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>不正な座標の基準局一覧テストデータ</title>
+</head>
+<body>
+  <table>
+    <tr>
+      <th>都市名</th>
+      <th>局名</th>
+      <th>北緯</th>
+      <th>東経</th>
+      <th>楕円体高</th>
+      <th>サーバアドレス</th>
+      <th>ポート番号</th>
+      <th>データ形式</th>
+      <th>接続方法</th>
+      <th>状態</th>
+      <th>メール連絡</th>
+      <th>コメント</th>
+    </tr>
+    <tr>
+      <td>テスト県座標異常市</td>
+      <td>座標異常基準局</td>
+      <td>not-a-number</td>
+      <td>139.123456</td>
+      <td>42.500</td>
+      <td>caster.example.test</td>
+      <td>2101</td>
+      <td>RTCM3</td>
+      <td>Ntrip</td>
+      <td>公開</td>
+      <td>○</td>
+      <td>緯度が数値ではないテストデータ</td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/Scraper/test/fixtures/reference_stations/missing_columns.html
+++ b/Scraper/test/fixtures/reference_stations/missing_columns.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>列不足の基準局一覧テストデータ</title>
+</head>
+<body>
+  <table>
+    <tr>
+      <th>都市名</th>
+      <th>局名</th>
+      <th>北緯</th>
+      <th>東経</th>
+      <th>楕円体高</th>
+      <th>サーバアドレス</th>
+      <th>ポート番号</th>
+      <th>データ形式</th>
+      <th>接続方法</th>
+      <th>状態</th>
+      <th>メール連絡</th>
+      <th>コメント</th>
+    </tr>
+    <tr>
+      <td>テスト県列不足市</td>
+      <td>列不足基準局</td>
+      <td>35.123456</td>
+      <td>139.123456</td>
+      <td>42.500</td>
+      <td>caster.example.test</td>
+      <td>2101</td>
+      <td>RTCM3</td>
+      <td>Ntrip</td>
+      <td>公開</td>
+      <td>○</td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/Scraper/test/fixtures/reference_stations/table_not_found.html
+++ b/Scraper/test/fixtures/reference_stations/table_not_found.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>基準局一覧テーブルなしのテストデータ</title>
+</head>
+<body>
+  <h1>別の一覧</h1>
+
+  <table>
+    <tr>
+      <th>名前</th>
+      <th>値</th>
+    </tr>
+    <tr>
+      <td>サンプル</td>
+      <td>123</td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/Scraper/test/fixtures/reference_stations/valid.html
+++ b/Scraper/test/fixtures/reference_stations/valid.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>基準局一覧テストデータ</title>
+</head>
+<body>
+  <h1>基準局一覧</h1>
+
+  <table>
+    <tr>
+      <th>都市名</th>
+      <th>局名</th>
+      <th>北緯</th>
+      <th>東経</th>
+      <th>楕円体高</th>
+      <th>サーバアドレス</th>
+      <th>ポート番号</th>
+      <th>データ形式</th>
+      <th>接続方法</th>
+      <th>状態</th>
+      <th>メール連絡</th>
+      <th>コメント</th>
+    </tr>
+    <tr>
+      <td>テスト県サンプル市</td>
+      <td>サンプル基準局A</td>
+      <td>35.123456</td>
+      <td>139.123456</td>
+      <td>42.500</td>
+      <td>caster-a.example.test</td>
+      <td>2101</td>
+      <td>RTCM3</td>
+      <td>Ntrip</td>
+      <td>公開</td>
+      <td>○</td>
+      <td>テスト用の正常データ</td>
+    </tr>
+    <tr>
+      <td>ダミー道例示町</td>
+      <td>サンプル基準局B</td>
+      <td>43.654321</td>
+      <td>141.654321</td>
+      <td>75.250</td>
+      <td>caster-b.example.test</td>
+      <td>2101</td>
+      <td>RTCM3</td>
+      <td>Ntrip</td>
+      <td>休止</td>
+      <td>×</td>
+      <td>
+        複数行コメントのテスト<br>
+        <a href="https://example.test/stations/sample-b">詳細</a>
+      </td>
+    </tr>
+    <tr>
+      <td>架空府検証市</td>
+      <td>サンプル基準局C</td>
+      <td>34.500000</td>
+      <td>135.500000</td>
+      <td>10.000</td>
+      <td>caster-c.example.test</td>
+      <td>80</td>
+      <td>u-blox</td>
+      <td>STRSVR</td>
+      <td>公開</td>
+      <td>○</td>
+      <td></td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/Scraper/test/fixtures/reference_stations/valid.html
+++ b/Scraper/test/fixtures/reference_stations/valid.html
@@ -53,6 +53,7 @@
         <a href="https://example.test/stations/sample-b">詳細</a>
       </td>
     </tr>
+    <tr></tr>
     <tr>
       <td>架空府検証市</td>
       <td>サンプル基準局C</td>

--- a/Scraper/test/reference_station_scraper_test.rb
+++ b/Scraper/test/reference_station_scraper_test.rb
@@ -1,0 +1,87 @@
+require 'minitest/autorun'
+require 'nokogiri'
+require 'json'
+require 'tmpdir'
+require_relative '../reference_station_scraper'
+
+class ReferenceStationScraperTest < Minitest::Test
+  VALID_FIXTURE_PATH = File.expand_path(
+    'fixtures/reference_stations/valid.html',
+    __dir__
+  )
+
+  MISSING_COLUMNS_FIXTURE_PATH = File.expand_path(
+    'fixtures/reference_stations/missing_columns.html',
+    __dir__
+  )
+
+  FIXED_TIME = Time.new(
+    2026,
+    7,
+    26,
+    0,
+    0,
+    0,
+    '+09:00'
+  )
+
+  # 正常なHTMLを処理した場合に、
+  # 検証済みの基準局データが連番ID付きでJSONへ出力されることを確認する。
+  def test_writes_valid_scraping_result
+    document = load_fixture(VALID_FIXTURE_PATH)
+
+    Dir.mktmpdir do |directory|
+      output_path = File.join(directory, 'result.json')
+
+      ReferenceStationScraper.run(
+        document,
+        output_path,
+        updated_at: FIXED_TIME
+      )
+
+      result = JSON.parse(
+        File.read(output_path, encoding: 'UTF-8')
+      )
+
+      assert_equal '2026-07-26 00:00:00', result['UpdateTime(JST)']
+      assert_equal 3, result['ReferenceStationData'].length
+      assert_equal(
+        [1, 2, 3],
+        result['ReferenceStationData'].map { |station| station['id'] }
+      )
+    end
+  end
+
+  # 基準局データの検証に失敗した場合に、
+  # 既存の正常な出力ファイルが変更されないことを確認する。
+  def test_preserves_existing_output_when_validation_fails
+    document = load_fixture(MISSING_COLUMNS_FIXTURE_PATH)
+
+    Dir.mktmpdir do |directory|
+      output_path = File.join(directory, 'result.json')
+      original_content = '{"existing":"valid data"}'
+
+      File.write(output_path, original_content)
+
+      assert_raises(ReferenceStationParser::ParseError) do
+        ReferenceStationScraper.run(
+          document,
+          output_path,
+          updated_at: FIXED_TIME
+        )
+      end
+
+      assert_equal(
+        original_content,
+        File.read(output_path, encoding: 'UTF-8')
+      )
+    end
+  end
+
+  private
+
+  def load_fixture(path)
+    html = File.read(path, encoding: 'UTF-8')
+    Nokogiri::HTML(html)
+  end
+end

--- a/Scraper/test/scrape_test.rb
+++ b/Scraper/test/scrape_test.rb
@@ -23,6 +23,11 @@ class ScrapeTest < Minitest::Test
     __dir__
   )
 
+  EMPTY_FIXTURE_PATH = File.expand_path(
+    'fixtures/reference_stations/empty.html',
+    __dir__
+  )
+
   def load_fixture(path)
     html = File.read(path, encoding: 'UTF-8')
     Nokogiri::HTML(html)
@@ -142,5 +147,17 @@ class ScrapeTest < Minitest::Test
     end
 
     assert_equal '基準局一覧テーブルが見つかりません', error.message
+  end
+
+  # 正しいヘッダーを持つ基準局一覧テーブルが存在していても、
+  # 基準局データが1件も含まれていない場合に解析エラーになることを確認する。
+  def test_raises_error_when_reference_station_data_is_empty
+    document = load_fixture(EMPTY_FIXTURE_PATH)
+
+    error = assert_raises(ReferenceStationParser::ParseError) do
+      ReferenceStationParser.parse_document(document)
+    end
+
+    assert_equal '基準局データが0件です', error.message
   end
 end

--- a/Scraper/test/scrape_test.rb
+++ b/Scraper/test/scrape_test.rb
@@ -13,6 +13,11 @@ class ScrapeTest < Minitest::Test
     __dir__
   )
 
+  INVALID_COORDINATES_FIXTURE_PATH = File.expand_path(
+    'fixtures/reference_stations/invalid_coordinates.html',
+    __dir__
+  )
+
   def setup
     html = File.read(VALID_FIXTURE_PATH, encoding: 'UTF-8')
     @document = Nokogiri::HTML(html)
@@ -35,8 +40,8 @@ class ScrapeTest < Minitest::Test
       {
         'city_name' => 'テスト県サンプル市',
         'station_name' => 'サンプル基準局A',
-        'latitude' => '35.123456',
-        'longitude' => '139.123456',
+        'latitude' => 35.123456,
+        'longitude' => 139.123456,
         'geoid_height' => '42.500',
         'server_address' => 'caster-a.example.test',
         'port_number' => '2101',
@@ -83,4 +88,57 @@ class ScrapeTest < Minitest::Test
     assert_includes error.message, 'expected=12'
     assert_includes error.message, 'actual=11'
   end
+
+  # 緯度に数値として解釈できない文字列が含まれている場合に、
+  # 不正な座標を出力せず解析エラーになることを確認する。
+  def test_raises_error_when_latitude_is_not_numeric
+    html = File.read(
+      INVALID_COORDINATES_FIXTURE_PATH,
+      encoding: 'UTF-8'
+    )
+    document = Nokogiri::HTML(html)
+    row = document.xpath('//tr')[1]
+
+    error = assert_raises(ReferenceStationParser::ParseError) do
+      ReferenceStationParser.parse_row(row)
+    end
+
+    assert_includes error.message, '緯度を数値へ変換できません'
+    assert_includes error.message, 'not-a-number'
+  end
+
+  # 緯度が許容範囲の-90度以上90度以下を超えている場合に、
+  # 地理座標として不正なデータを検出できることを確認する。
+  def test_raises_error_when_latitude_is_out_of_range
+    html = File.read(VALID_FIXTURE_PATH, encoding: 'UTF-8')
+    document = Nokogiri::HTML(html)
+    row = document.xpath('//tr')[1]
+
+    row.css('td')[2].content = '91.0'
+
+    error = assert_raises(ReferenceStationParser::ParseError) do
+      ReferenceStationParser.parse_row(row)
+    end
+
+    assert_includes error.message, '緯度が範囲外です'
+    assert_includes error.message, 'value=91.0'
+  end
+
+  # 経度が許容範囲の-180度以上180度以下を超えている場合に、
+  # 地理座標として不正なデータを検出できることを確認する。
+  def test_raises_error_when_longitude_is_out_of_range
+    html = File.read(VALID_FIXTURE_PATH, encoding: 'UTF-8')
+    document = Nokogiri::HTML(html)
+    row = document.xpath('//tr')[1]
+
+    row.css('td')[3].content = '181.0'
+
+    error = assert_raises(ReferenceStationParser::ParseError) do
+      ReferenceStationParser.parse_row(row)
+    end
+
+    assert_includes error.message, '経度が範囲外です'
+    assert_includes error.message, 'value=181.0'
+  end
+
 end

--- a/Scraper/test/scrape_test.rb
+++ b/Scraper/test/scrape_test.rb
@@ -3,13 +3,18 @@ require 'nokogiri'
 require_relative '../reference_station_parser'
 
 class ScrapeTest < Minitest::Test
-  FIXTURE_PATH = File.expand_path(
+  VALID_FIXTURE_PATH = File.expand_path(
     'fixtures/reference_stations/valid.html',
     __dir__
   )
 
+  MISSING_COLUMNS_FIXTURE_PATH = File.expand_path(
+    'fixtures/reference_stations/missing_columns.html',
+    __dir__
+  )
+
   def setup
-    html = File.read(FIXTURE_PATH, encoding: 'UTF-8')
+    html = File.read(VALID_FIXTURE_PATH, encoding: 'UTF-8')
     @document = Nokogiri::HTML(html)
   end
 
@@ -59,5 +64,23 @@ class ScrapeTest < Minitest::Test
       station['comment'],
       '<a href="https://example.test/stations/sample-b">詳細</a>'
     )
+  end
+
+  # 必要な12列を持たない基準局行を解析した場合に、
+  # 不完全なデータを生成せず解析エラーになることを確認する。
+  def test_raises_error_when_reference_station_row_has_missing_columns
+    html = File.read(
+      MISSING_COLUMNS_FIXTURE_PATH,
+      encoding: 'UTF-8'
+    )
+    document = Nokogiri::HTML(html)
+    row = document.xpath('//tr')[1]
+
+    error = assert_raises(ReferenceStationParser::ParseError) do
+      ReferenceStationParser.parse_row(row)
+    end
+
+    assert_includes error.message, 'expected=12'
+    assert_includes error.message, 'actual=11'
   end
 end

--- a/Scraper/test/scrape_test.rb
+++ b/Scraper/test/scrape_test.rb
@@ -18,21 +18,25 @@ class ScrapeTest < Minitest::Test
     __dir__
   )
 
+  TABLE_NOT_FOUND_FIXTURE_PATH = File.expand_path(
+    'fixtures/reference_stations/table_not_found.html',
+    __dir__
+  )
+
+  def load_fixture(path)
+    html = File.read(path, encoding: 'UTF-8')
+    Nokogiri::HTML(html)
+  end
+
   def setup
-    html = File.read(VALID_FIXTURE_PATH, encoding: 'UTF-8')
-    @document = Nokogiri::HTML(html)
+    @document = load_fixture(VALID_FIXTURE_PATH)
   end
 
   # 正常な基準局一覧HTMLを読み込んだ場合に、
+  # ヘッダーが一致するテーブルを特定し、
   # すべてのデータ行を基準局データとして解析できることを確認する。
-  #
-  # また、先頭行の各列が想定されたキーへ正しく対応していることを確認する。
-  def test_reads_reference_station_rows
-    rows = @document.xpath('//tr').drop(1)
-
-    stations = rows.map do |row|
-        ReferenceStationParser.parse_row(row)
-    end
+  def test_parses_reference_station_table
+    stations = ReferenceStationParser.parse_document(@document)
 
     assert_equal 3, stations.length
 
@@ -57,12 +61,9 @@ class ScrapeTest < Minitest::Test
 
   # コメント欄に改行タグやリンクが含まれている場合に、
   # テキストへ変換せずHTMLとして保持されることを確認する。
-  #
-  # 現行実装ではコメント欄だけinner_htmlを使用しているため、
-  # リファクタリング後も同じ出力形式が維持されることを保証する。
   def test_preserves_html_in_comment
-    rows = @document.xpath('//tr').drop(1)
-    station = ReferenceStationParser.parse_row(rows[1])
+    stations = ReferenceStationParser.parse_document(@document)
+    station = stations[1]
 
     assert_includes station['comment'], '<br>'
     assert_includes(
@@ -74,11 +75,7 @@ class ScrapeTest < Minitest::Test
   # 必要な12列を持たない基準局行を解析した場合に、
   # 不完全なデータを生成せず解析エラーになることを確認する。
   def test_raises_error_when_reference_station_row_has_missing_columns
-    html = File.read(
-      MISSING_COLUMNS_FIXTURE_PATH,
-      encoding: 'UTF-8'
-    )
-    document = Nokogiri::HTML(html)
+    document = load_fixture(MISSING_COLUMNS_FIXTURE_PATH)
     row = document.xpath('//tr')[1]
 
     error = assert_raises(ReferenceStationParser::ParseError) do
@@ -92,11 +89,7 @@ class ScrapeTest < Minitest::Test
   # 緯度に数値として解釈できない文字列が含まれている場合に、
   # 不正な座標を出力せず解析エラーになることを確認する。
   def test_raises_error_when_latitude_is_not_numeric
-    html = File.read(
-      INVALID_COORDINATES_FIXTURE_PATH,
-      encoding: 'UTF-8'
-    )
-    document = Nokogiri::HTML(html)
+    document = load_fixture(INVALID_COORDINATES_FIXTURE_PATH)
     row = document.xpath('//tr')[1]
 
     error = assert_raises(ReferenceStationParser::ParseError) do
@@ -110,8 +103,7 @@ class ScrapeTest < Minitest::Test
   # 緯度が許容範囲の-90度以上90度以下を超えている場合に、
   # 地理座標として不正なデータを検出できることを確認する。
   def test_raises_error_when_latitude_is_out_of_range
-    html = File.read(VALID_FIXTURE_PATH, encoding: 'UTF-8')
-    document = Nokogiri::HTML(html)
+    document = load_fixture(VALID_FIXTURE_PATH)
     row = document.xpath('//tr')[1]
 
     row.css('td')[2].content = '91.0'
@@ -127,8 +119,7 @@ class ScrapeTest < Minitest::Test
   # 経度が許容範囲の-180度以上180度以下を超えている場合に、
   # 地理座標として不正なデータを検出できることを確認する。
   def test_raises_error_when_longitude_is_out_of_range
-    html = File.read(VALID_FIXTURE_PATH, encoding: 'UTF-8')
-    document = Nokogiri::HTML(html)
+    document = load_fixture(VALID_FIXTURE_PATH)
     row = document.xpath('//tr')[1]
 
     row.css('td')[3].content = '181.0'
@@ -141,4 +132,15 @@ class ScrapeTest < Minitest::Test
     assert_includes error.message, 'value=181.0'
   end
 
+  # 基準局一覧のヘッダーを持つテーブルが存在しない場合に、
+  # 別のテーブルを誤って解析せずエラーになることを確認する。
+  def test_raises_error_when_reference_station_table_is_not_found
+    document = load_fixture(TABLE_NOT_FOUND_FIXTURE_PATH)
+
+    error = assert_raises(ReferenceStationParser::ParseError) do
+      ReferenceStationParser.parse_document(document)
+    end
+
+    assert_equal '基準局一覧テーブルが見つかりません', error.message
+  end
 end

--- a/Scraper/test/scrape_test.rb
+++ b/Scraper/test/scrape_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 require 'nokogiri'
-require_relative '../scrape'
+require_relative '../reference_station_parser'
 
 class ScrapeTest < Minitest::Test
   FIXTURE_PATH = File.expand_path(
@@ -21,7 +21,7 @@ class ScrapeTest < Minitest::Test
     rows = @document.xpath('//tr').drop(1)
 
     stations = rows.map do |row|
-      read_kijunkyoku_table_row(row)
+        ReferenceStationParser.parse_row(row)
     end
 
     assert_equal 3, stations.length
@@ -52,7 +52,7 @@ class ScrapeTest < Minitest::Test
   # リファクタリング後も同じ出力形式が維持されることを保証する。
   def test_preserves_html_in_comment
     rows = @document.xpath('//tr').drop(1)
-    station = read_kijunkyoku_table_row(rows[1])
+    station = ReferenceStationParser.parse_row(rows[1])
 
     assert_includes station['comment'], '<br>'
     assert_includes(

--- a/Scraper/test/scrape_test.rb
+++ b/Scraper/test/scrape_test.rb
@@ -1,0 +1,63 @@
+require 'minitest/autorun'
+require 'nokogiri'
+require_relative '../scrape'
+
+class ScrapeTest < Minitest::Test
+  FIXTURE_PATH = File.expand_path(
+    'fixtures/reference_stations/valid.html',
+    __dir__
+  )
+
+  def setup
+    html = File.read(FIXTURE_PATH, encoding: 'UTF-8')
+    @document = Nokogiri::HTML(html)
+  end
+
+  # 正常な基準局一覧HTMLを読み込んだ場合に、
+  # すべてのデータ行を基準局データとして解析できることを確認する。
+  #
+  # また、先頭行の各列が想定されたキーへ正しく対応していることを確認する。
+  def test_reads_reference_station_rows
+    rows = @document.xpath('//tr').drop(1)
+
+    stations = rows.map do |row|
+      read_kijunkyoku_table_row(row)
+    end
+
+    assert_equal 3, stations.length
+
+    assert_equal(
+      {
+        'city_name' => 'テスト県サンプル市',
+        'station_name' => 'サンプル基準局A',
+        'latitude' => '35.123456',
+        'longitude' => '139.123456',
+        'geoid_height' => '42.500',
+        'server_address' => 'caster-a.example.test',
+        'port_number' => '2101',
+        'data_type' => 'RTCM3',
+        'connection_type' => 'Ntrip',
+        'status' => '公開',
+        'mail' => '○',
+        'comment' => 'テスト用の正常データ'
+      },
+      stations.first
+    )
+  end
+
+  # コメント欄に改行タグやリンクが含まれている場合に、
+  # テキストへ変換せずHTMLとして保持されることを確認する。
+  #
+  # 現行実装ではコメント欄だけinner_htmlを使用しているため、
+  # リファクタリング後も同じ出力形式が維持されることを保証する。
+  def test_preserves_html_in_comment
+    rows = @document.xpath('//tr').drop(1)
+    station = read_kijunkyoku_table_row(rows[1])
+
+    assert_includes station['comment'], '<br>'
+    assert_includes(
+      station['comment'],
+      '<a href="https://example.test/stations/sample-b">詳細</a>'
+    )
+  end
+end

--- a/Scraper/test/scraping_result_writer_test.rb
+++ b/Scraper/test/scraping_result_writer_test.rb
@@ -1,0 +1,56 @@
+require 'minitest/autorun'
+require 'json'
+require 'tmpdir'
+require_relative '../scraping_result_writer'
+
+class ScrapingResultWriterTest < Minitest::Test
+  # 新しいJSONが一時ファイルへ書き込まれた後、
+  # 既存の出力ファイルを正常に置き換えられることを確認する。
+  def test_replaces_output_file_after_writing_temp_file
+    Dir.mktmpdir do |directory|
+      output_path = File.join(directory, 'result.json')
+      File.write(output_path, '{"old":true}')
+
+      result = {
+        'ReferenceStationData' => [
+          {
+            'id' => 1,
+            'station_name' => 'サンプル基準局'
+          }
+        ]
+      }
+
+      ScrapingResultWriter.write(output_path, result)
+
+      written_result = JSON.parse(
+        File.read(output_path, encoding: 'UTF-8')
+      )
+
+      assert_equal result, written_result
+      assert_empty Dir.glob(File.join(directory, '*.tmp'))
+    end
+  end
+
+  # JSON生成に失敗した場合に、
+  # 既存の出力ファイルが変更されないことを確認する。
+  def test_preserves_output_file_when_json_generation_fails
+    Dir.mktmpdir do |directory|
+      output_path = File.join(directory, 'result.json')
+      original_content = '{"old":true}'
+
+      File.write(output_path, original_content)
+
+      recursive_array = []
+      recursive_array << recursive_array
+
+      assert_raises(JSON::NestingError) do
+        ScrapingResultWriter.write(output_path, recursive_array)
+      end
+
+      assert_equal(
+        original_content,
+        File.read(output_path, encoding: 'UTF-8')
+      )
+    end
+  end
+end


### PR DESCRIPTION
**参照**

Closes #12

**変更の内容**

スクレイピング処理を解析・検証・出力の段階に分離した。

取得元HTMLから基準局一覧テーブルをヘッダーによって特定し、以下の検証を追加した。

* 基準局行が想定する12列を持つことを確認した。
* 空行を解析対象から除外した。
* 緯度・経度を数値へ変換した。
* 緯度が-90度以上90度以下であることを確認した。
* 経度が-180度以上180度以下であることを確認した。
* 基準局の取得結果が0件の場合は処理を失敗させるようにした。

JSONの出力処理を分離し、一時ファイルへの書き込みが完了した場合のみ`result.json`を置き換えるようにした。解析または検証に失敗した場合は、既存のJSONを維持する。

正常系、列不足、不正な座標、対象テーブルなし、取得結果0件のHTML fixtureを追加した。また、JSON出力処理とスクレイピング処理全体に対する自動テストを追加した。

GitHub Actionsへテストワークフローを追加し、定期スクレイピングの実行前にもテストを実行するようにした。