### PR TITLE
fix: 基準局情報の取得日時をJSTで正しく記録する (#21)

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -3,7 +3,9 @@ name: Scrape action
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 15 * * *' # 毎日日本時間の0時に更新
+    # GitHub ActionsのcronはUTC基準。
+    # 毎日 15:00 UTC（翌日 00:00 JST）に実行する。
+    - cron: '0 15 * * *'
 
 permissions:
   contents: read

--- a/Scraper/reference_station_scraper.rb
+++ b/Scraper/reference_station_scraper.rb
@@ -4,6 +4,9 @@ require_relative 'scraping_result_writer'
 module ReferenceStationScraper
   # HTMLを解析して出力用データを生成し、
   # すべての検証に成功した場合のみJSONファイルへ書き込む。
+
+  JST_OFFSET = '+09:00'
+
   def self.run(document, output_path, updated_at: Time.now)
     # HTMLから基準局一覧を解析し、検証済みの基準局データを取得
     reference_stations =
@@ -18,7 +21,7 @@ module ReferenceStationScraper
 
     # 出力するJSONデータを作成
     result = {
-      'UpdateTime(JST)' => updated_at.strftime('%Y-%m-%d %H:%M:%S'),
+      'UpdateTime(JST)' => updated_at.getlocal(JST_OFFSET).strftime('%Y-%m-%d %H:%M:%S'),
       'ReferenceStationData' => station_data
     }
 

--- a/Scraper/test/reference_station_scraper_test.rb
+++ b/Scraper/test/reference_station_scraper_test.rb
@@ -78,6 +78,25 @@ class ReferenceStationScraperTest < Minitest::Test
     end
   end
 
+  # UTCの取得日時がJSTへ変換され、
+  # 日付をまたぐ場合も正しい日時になることを確認する。
+  def test_converts_utc_updated_at_to_jst
+    document = load_fixture(VALID_FIXTURE_PATH)
+    updated_at = Time.utc(2026, 7, 27, 17, 1, 4)
+
+    Dir.mktmpdir do |directory|
+      output_path = File.join(directory, 'result.json')
+
+      result = ReferenceStationScraper.run(
+        document,
+        output_path,
+        updated_at: updated_at
+      )
+
+      assert_equal '2026-07-28 02:01:04', result['UpdateTime(JST)']
+    end
+  end
+
   private
 
   def load_fixture(path)


### PR DESCRIPTION
**参照**
Closes #21

**変更の内容**

* 基準局情報の取得日時をJSTへ変換してから `UpdateTime(JST)` に保存するようにした。
* JSTのUTCオフセットを定数として定義した。
* UTCの日時を渡した場合に、正しいJSTへ変換されることを確認するテストを追加した。
* GitHub ActionsのcronがUTC基準であり、毎日15:00 UTC（翌日00:00 JST）に実行する設定であることをコメントに明記した。
